### PR TITLE
require() with dynamic array argument

### DIFF
--- a/lib/callHandler/amd.js
+++ b/lib/callHandler/amd.js
@@ -102,7 +102,7 @@ define([
 
 		// TODO: If dependencyIds array is non-existent, need to scan for require(str) calls in the factory function
 		// string, blah.
-		dependencyIds = dependencyIds ? dependencyIds.toArray() : [];
+		dependencyIds = (dependencyIds && dependencyIds.type === Value.TYPE_ARRAY) ? dependencyIds.toArray() : [];
 
 		var resolvedArgs = [];
 


### PR DESCRIPTION
require(foo, ...): doc parser doesn't know what's inside the foo[] array, or even that it's an array.

This is to get dojox/mobile/dh/JsonContentHander.js to parse [again].   Presumably broke with 80d87cb851c8e4ad6c02d61059c5874e1f2907dc.

cc @ykami
