### PR TITLE
rudimentary handler for dojox/drawing/util/oo::declare()

### DIFF
--- a/lib/callHandler/dojo.js
+++ b/lib/callHandler/dojo.js
@@ -198,6 +198,60 @@ define([
 		return value;
 	});
 
+	// Theoretically this should also be able to handle ComposeJS
+	handlers.register('drawingDeclare', util.isModuleProperty('dojox/drawing/util/oo', 'declare'), function (callInfo, args) {
+		function getMixinModule(value) {
+			// The mixin is not exposed as a module, i.e. it is local to the value itself
+			// In this case it seems best to just lie and report the mixin’s mixins, but maybe it is
+			// better to create a pseudo-module instead
+			if (!value.relatedModule) {
+				return value.mixins.slice(0);
+			}
+
+			return value.relatedModule;
+		}
+
+		var mixins		  = args.slice(0, -2).map(function(f){ return f.evaluated; }),
+			constructor   = (args[args.length - 2] || {}).evaluated, // TODO: process this
+			prototype     = (args[args.length - 1] || {}).evaluated;
+
+		var mixinModules = mixins.map(getMixinModule);
+
+		// The newly created constructor
+		var value = new Value({
+			type: Value.TYPE_CONSTRUCTOR,
+			mixins: mixinModules
+		});
+
+		value.metadata.classlike = true;
+
+		// An instance of the first mixin is the delegate for the new constructor, if one exists
+		if (mixins.length) {
+			prototype.setProperty('prototype', new Value({ type: Value.TYPE_INSTANCE, value: mixins[0] }));
+		}
+
+		// All subsequent mixins have their properties copied over to the new constructor’s prototype
+		for (var i = 1, mixin; (mixin = mixins[i]); ++i) {
+			mixin = mixin.getProperty('prototype');
+
+			if (!mixin) {
+				throw new Error('Mixin #' + i + ' has no prototype');
+			}
+
+			// Only copy over existing prototype properties;
+			// TODO: May want to copy metadata regardless, though
+			for (var k in mixin.properties) {
+				if (_hasOwnProperty.call(mixin.properties, k) && !_hasOwnProperty.call(prototype.properties, k)) {
+					prototype.setProperty(k, mixin.properties[k]);
+				}
+			}
+		}
+
+		value.setProperty('prototype', prototype);
+
+		return value;
+	});
+
 	handlers.register('mixin', util.isModuleProperty('dojo/_base/lang', 'mixin'), handleMixin);
 	handlers.register('_mixin', util.isModuleProperty('dojo/_base/lang', '_mixin'), handleMixin);
 	handlers.register('safeMixin', util.isModuleProperty('dojo/_base/declare', 'safeMixin'), handleMixin);


### PR DESCRIPTION
This gets the dojox/drawing/util/oo::declare'd classes to show up in the doc, although it doesn't handle the constructor(s) specified for the classes.   Couldn't figure out how to do that.
