### PR TITLE
Use configuration file instead of specifying packages on command-line

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,7 +39,7 @@ define({
 	// Configuration data for module ID resolution and path remapping within the parser.
 	// TODO: Document
 	environmentConfig: {
-		basePath: '',
+		basePath: '../trunk',
 		packages: {
 			dojo: 'dojo',
 			dijit: 'dijit',

--- a/config.js
+++ b/config.js
@@ -50,6 +50,9 @@ define({
 			// Non-API code
 			/\/(?:tests|nls|demos)\//,
 
+			// Defines a "module" called "commandLineArgs" except it's defined inline rather than as a file called commandLineArgs.js
+			/util\/build/,
+
 			// Overwrites dojo.declare
 			/dojox\/lang\/(?:docs|typed)/
 		]


### PR DESCRIPTION
This will allow for easier skipping of certain packages without requiring lots of command-line typing, and improve the ability to handle non-dojo source code for processing.
