### PR TITLE
dojodoc indentation processing

### DIFF
--- a/lib/exporter/dojov1.js
+++ b/lib/exporter/dojov1.js
@@ -1,4 +1,12 @@
-define([ '../Module', '../Value', './util', '../console', '../node!fs' ], function (Module, Value, util, console, fs) {
+define([
+	'dojo/string',
+	'../Module',
+	'../Value',
+	'./util',
+	'../console',
+	'dojo/node!fs',
+], function (stringUtil, Module, Value, util, console, fs) {
+
 	/**
 	 * Takes information from metadata stored alongside a Value and adds it to the output.
 	 * @param node The node to add metadata to.
@@ -35,6 +43,66 @@ define([ '../Module', '../Value', './util', '../console', '../node!fs' ], functi
 	}
 
 	/**
+	 * Given metadata with a type annotation, attempt to resolve the annotated type as an object and (hackily) apply
+	 * information about the object’s default properties to the metadata description property.
+	 */
+	function processTypeAnnotation(/**Object*/ metadata) {
+		if (!metadata.type || typeof metadata.type === 'string') {
+			return;
+		}
+
+		var propertyTemplate = '<li>${key}${type}${summary}</li>',
+			annotationObject = metadata.type,
+			additionalDescription = '';
+
+		if (annotationObject.relatedModule) {
+			metadata.type = annotationObject.relatedModule.id;
+			return;
+		}
+
+		metadata.type = 'Object';
+		additionalDescription += '<p>' + (metadata.description ?
+					'The following properties are supported:' :
+					'An object with the following properties:') + '</p><ul>';
+
+		(function readProperties(object) {
+			var propertyMetadata,
+				properties = object.properties,
+				k;
+
+			// if the annotationObject is a function, we don't want to pick up any properties apart
+			// from what's on the prototype.
+			if (object.type === 'function') {
+				if (_hasOwnProperty.call(properties, 'prototype')) {
+					readProperties(properties.prototype);
+				}
+				return;
+			}
+
+			for (k in properties) {
+				if (_hasOwnProperty.call(properties, k)) {
+					// Type descriptor could be a plain JS object, or could be a constructor. It is often the
+					// latter.
+					if (k === 'prototype') {
+						readProperties(properties[k]);
+					}
+					// Filter out built-ins and constructor properties which come from dojo/_base/declare
+					else if (k !== 'constructor' && properties[k].file) {
+						propertyMetadata = properties[k].metadata;
+						additionalDescription += stringUtil.substitute(propertyTemplate, {
+							key: k,
+							type: propertyMetadata.type ? ' (' + propertyMetadata.type + (propertyMetadata.isOptional ? ', optional' : '') + ')' : '',
+							summary: propertyMetadata.summary ? ': ' + propertyMetadata.summary : ''
+						});
+					}
+				}
+			}
+		}(annotationObject));
+
+		metadata.description = (metadata.description || '') + additionalDescription + '</ul>';
+	}
+
+	/**
 	 * Takes an array of return Values and processes it for return types, discarding all
 	 * duplicates, and applies the resulting list of properties to the node given in returnsNode.
 	 * @param returnsNode The XML node to add return types to.
@@ -67,6 +135,9 @@ define([ '../Module', '../Value', './util', '../console', '../node!fs' ], functi
 			i;
 
 		for (i = 0; (parameter = property.parameters[i]); ++i) {
+			if (typeof parameter.metadata.type !== 'string') {
+				processTypeAnnotation(parameter.metadata);
+			}
 			parameterType = parameter.metadata.type || parameter.type || 'unknown';
 			parameterNode = parametersNode.createNode('parameter', {
 				name: parameter.name,
@@ -105,6 +176,9 @@ define([ '../Module', '../Value', './util', '../console', '../node!fs' ], functi
 			propertyNode;
 
 		function makePropertyObject(name, value) {
+			if (typeof value.metadata.type !== 'string') {
+				processTypeAnnotation(value.metadata);
+			}
 			var object = {
 				name: name,
 				scope: scope,

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -45,13 +45,21 @@ define([
 	 * avoid accidentally overwriting data that already exists with empty data.
 	 */
 	function mixinMetadata(destination, source) {
-		for (var k in source) {
+		var raw,
+			k;
+
+		for (k in source) {
 			if (_hasOwnProperty.call(source, k) && source[k]) {
 				if (source[k] instanceof Array && destination[k] instanceof Array) {
 					destination[k] = destination[k].concat(source[k]);
 				}
 				else if (k === 'type' && typeof source[k] === 'string') {
 					destination[k] = source[k].replace(optionalTypeRe, '');
+				}
+				else if (k === 'raw') {
+					// this keeps the mixin/override semantics of raw the same as the metadata itself
+					raw = destination[k];
+					raw ? mixinMetadata(raw, source[k]) : destination[k] = source[k];
 				}
 				else if (typeof source[k] !== 'string' || trim(source[k])) {
 					destination[k] = source[k];
@@ -165,7 +173,13 @@ define([
 	function processMetadata(/**Object*/ metadata) {
 		var example,
 			i,
-			k;
+			k,
+			raw = metadata.raw = {
+				summary: metadata.summary,
+				description: metadata.description,
+				// handle examples in the loop below to avoid redundant iteration.  also, by
+				// recursing for properties and returns, they will get their own raw objects.
+			};
 
 		// The style guide says `summary` isn’t markdown, only `description` is markdown, but everyone sticks markdown
 		// in the summary anyway, so handle it as markdown too
@@ -173,7 +187,9 @@ define([
 		metadata.description = parseMarkdown(metadata.description || '');
 
 		if (metadata.examples) {
+			raw.examples = [];
 			for (i = 0; (example = metadata.examples[i]); ++i) {
+				raw.examples[i] = example;
 				metadata.examples[i] = parseMarkdown(example);
 			}
 		}

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -88,8 +88,9 @@ define([
 		var tags = [],
 			tag;
 
+		// The standard is to put all the tags within one set of brackets, but we'll allow for multiple brackets too.
 		while ((tag = tagRe.exec(keyLine))) {
-			tags.push(tag[1]);
+			tags = tags.concat(tag[1].trim().split(/ +/));
 		}
 
 		return tags;
@@ -126,7 +127,11 @@ define([
 		key = standardKeys[key];
 
 		if (key === 'tags') {
-			metadata[key] = metadata[key].concat(line.split(/\s+/));
+			// Usually we get one blank "line" because we are first called to process the text after "tags:",
+			// on the same line, and then called with the real data from the next line
+			if(line && line.trim()) {
+				metadata[key] = metadata[key].concat(line.trim().split(/\s+/));
+			}
 		}
 		else if (metadata[key] instanceof Array) {
 			metadata[key][metadata[key].length - 1] += (metadata[key][metadata[key].length - 1].length ? '\n' : '') + line;

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -442,6 +442,9 @@ define([
 
 					metadata = (processComment(candidate.value, value.raw.key.name).properties || {})[value.raw.key.name];
 					processTypeAnnotation(metadata);
+					// the localised property metadata will override the metadata inherited from the value
+					context.evaluated.properties[value.raw.key.name].metadata = metadata;
+					return;
 				}
 			}
 

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -237,17 +237,12 @@ define([
 				examples: [],
 				properties: {}
 			},
-			keyIndent = indentRe.exec(comment[0].replace(/\t/g, '    '))[0].length,
+			keyIndent = indentRe.exec(comment[0])[0].length,
 			valueIndent,	// indent of the line after the current key
 			line,
 			key;
 
 		while ((line = comment.shift()) != null) {
-			// Some doc blocks mix tabs and spaces so that they appear indented correctly but actually use the
-			// same number of characters, which breaks the indentation context
-			// TODO: should also account for spaces followed by tabs
-			line = line.replace(/\t/g, '    ');
-
 			// New metadata key
 			// Lines with no length, or lines with a length equal to the key indent, are just blank lines
 			if (line.length && indentRe.exec(line)[0].length === keyIndent && line.length !== keyIndent) {
@@ -342,6 +337,27 @@ define([
 		return metadata;
 	}
 
+	/**
+	 * Convert tabs in a string to spaces, assuming 4 space tabs.
+	 */
+	function softtab(/**string*/ str){
+		var cnt = 0, spaces = ["    ", "   ", "  ", " "];
+		return str.replace(/\t|\n|[^\t\n]+/g, function(match){
+			switch(match){
+				case '\t':
+					match = spaces[cnt%4];
+				// fall through
+				case '\n':
+					cnt = 0;
+					break;
+				default:
+					cnt += match.length;
+					break;
+			}
+			return match;
+		});
+	}
+
 	return {
 		/**
 		 * Processes raw source code prior to being parsed.
@@ -349,6 +365,10 @@ define([
 		 * @returns {string} Processed source code.
 		 */
 		processSource: function (/**string*/ source) {
+			// Convert tabs to spaces to avoid confusion about alignment (of keys or the lines of a value for keys)
+			source = softtab(source);
+
+			// Comments like /*===== var x = 5; =====*/ are meant to be parsed as though they were normal code.
 			return source.replace(/\/\*={5,}|={5,}\*\//g, '');
 		},
 

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -217,7 +217,7 @@ define([
 		if (metadata.properties) {
 			for (k in metadata.properties) {
 				if (_hasOwnProperty.call(metadata.properties, k)) {
-					metadata.properties[k].summary = parseMarkdown(metadata.properties[k].summary);
+					processMetadata(metadata.properties[k]);
 				}
 			}
 		}

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -195,6 +195,39 @@ define([
 	}
 
 	/**
+	 * Processes metadata to parse the markdown of certain properties
+	 * @param metadata Metadata object to parse for markdown
+	 */
+	function processMetadata(/**Object*/ metadata) {
+		var example,
+			i,
+			k;
+
+		// The style guide says `summary` isn’t markdown, only `description` is markdown, but everyone sticks markdown
+		// in the summary anyway, so handle it as markdown too
+		metadata.summary = parseMarkdown(metadata.summary || '');
+		metadata.description = parseMarkdown(metadata.description || '');
+
+		if (metadata.examples) {
+			for (i = 0; (example = metadata.examples[i]); ++i) {
+				metadata.examples[i] = parseMarkdown(example);
+			}
+		}
+
+		if (metadata.properties) {
+			for (k in metadata.properties) {
+				if (_hasOwnProperty.call(metadata.properties, k)) {
+					metadata.properties[k].summary = parseMarkdown(metadata.properties[k].summary);
+				}
+			}
+		}
+
+		if (metadata.returns) {
+			processMetadata(metadata.returns);
+		}
+	}
+
+	/**
 	 * Processes a dojodoc multi-line comment block, which consists of key lines that identify the metadata and
 	 * subsequent indented lines containing the actual metadata.
 	 * @param comment The comment block.
@@ -306,19 +339,7 @@ define([
 			}
 		}
 
-		// The style guide says `summary` isn’t markdown, only `description` is markdown, but everyone sticks markdown
-		// in the summary anyway, so handle it as markdown too
-		metadata.summary = parseMarkdown(metadata.summary);
-		metadata.description = parseMarkdown(metadata.description);
-		for (var i = 0, example; (example = metadata.examples[i]); ++i) {
-			metadata.examples[i] = parseMarkdown(example);
-		}
-
-		for (var k in metadata.properties) {
-			if (_hasOwnProperty.call(metadata.properties, k)) {
-				metadata.properties[k].summary = parseMarkdown(metadata.properties[k].summary);
-			}
-		}
+		processMetadata(metadata);
 
 		return metadata;
 	}

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -150,8 +150,6 @@ define([
 	function processStandardKey(/**Object*/ metadata, /**string*/ key, /**string*/ line) {
 		key = standardKeys[key];
 
-		line = trim(line);
-
 		if (key === 'tags') {
 			metadata[key] = metadata[key].concat(line.split(/\s+/));
 		}
@@ -239,14 +237,16 @@ define([
 				examples: [],
 				properties: {}
 			},
-			keyIndent = indentRe.exec(comment[0].replace(/\t/g, '  '))[0].length,
+			keyIndent = indentRe.exec(comment[0].replace(/\t/g, '    '))[0].length,
+			valueIndent,	// indent of the line after the current key
 			line,
 			key;
 
 		while ((line = comment.shift()) != null) {
 			// Some doc blocks mix tabs and spaces so that they appear indented correctly but actually use the
 			// same number of characters, which breaks the indentation context
-			line = line.replace(/\t/g, '  ');
+			// TODO: should also account for spaces followed by tabs
+			line = line.replace(/\t/g, '    ');
 
 			// New metadata key
 			// Lines with no length, or lines with a length equal to the key indent, are just blank lines
@@ -254,6 +254,9 @@ define([
 				var keyLine = keyRe.exec(line);
 
 				key = standardKeys[keyLine[1]] || keyLine[1];
+
+				// Flag that when we read the next line, need to measure the indent
+				valueIndent = 0;
 
 				// TODO messages look exactly like a property or parameter definition, but they aren’t, so
 				// ignore them
@@ -310,6 +313,21 @@ define([
 
 			// Continuation of previous key
 			else if (key) {
+
+				if(!valueIndent /* && line */){
+					// First (non-blank) line after a key.  Use this line to measure the base indent of the value of this key.
+					try {
+						valueIndent = indentRe.exec(line)[0].length;
+					}catch(e){
+						console.error("Error measuring indent of line: " + line + " after key: " + key);
+						throw e;
+					}
+				}
+
+				// Trim the indentation that's part of dojodoc, but not the indentation that's part of markdown,
+				// representing nested lists or code blocks.
+				line = line.substr(valueIndent);
+
 				if (!forKey && standardKeys.hasOwnProperty(key)) {
 					processStandardKey(metadata, key, line);
 				}

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -50,7 +50,7 @@ define([
 				if (source[k] instanceof Array && destination[k] instanceof Array) {
 					destination[k] = destination[k].concat(source[k]);
 				}
-				else if (k === 'type') {
+				else if (k === 'type' && typeof source[k] === 'string') {
 					destination[k] = source[k].replace(optionalTypeRe, '');
 				}
 				else if (typeof source[k] !== 'string' || trim(source[k])) {
@@ -113,60 +113,24 @@ define([
 	}
 
 	/**
-	 * Given metadata with a type annotation, attempt to resolve the annotated type as an object and (hackily) apply
-	 * information about the object’s default properties to the metadata description property.
-	 * TODO: This should really end up happening in the dojov1 exporter instead.
+	 * Given metadata with a type annotation, attempt to resolve the annotated type as an object and
+	 * provide that object to the exporter as the type property of the metadata.
 	 */
 	function processTypeAnnotation(/**Object*/ metadata) {
 		if (!metadata.type) {
 			return;
 		}
 
-		var propertyTemplate = '\n* ${key}${type}${summary}',
-			annotationObject = env.scope.getVariable(metadata.type.replace(/[^\w$\.]+$/g, '').split('.')),
-			additionalDescription = '';
+		var annotationObject = env.scope.getVariable(metadata.type.replace(/[^\w$\.]+$/g, '').split('.'));
 
 		if (!annotationObject || annotationObject.type === Value.TYPE_UNDEFINED || /* not a built-in */ !annotationObject.file) {
 			return;
 		}
 
-		if (annotationObject.relatedModule) {
-			metadata.type = annotationObject.relatedModule.id;
-			return;
-		}
-
-		// TODO: The fact that evaluate exists on annotation objects seems to indicate that we’re failing to
-		// evaluate all function expressions; this might be an issue
-		annotationObject.evaluate && annotationObject.evaluate();
-
-		metadata.type = 'Object';
-		additionalDescription += metadata.description ?
-			'\n\nThe following properties are supported:\n' :
-			'An object with the following properties:\n';
-
-		(function readProperties(object) {
-			var propertyMetadata;
-			for (var k in object.properties) {
-				if (_hasOwnProperty.call(object.properties, k)) {
-					// Type descriptor could be a plain JS object, or could be a constructor. It is often the
-					// latter.
-					if (k === 'prototype') {
-						readProperties(object.properties[k]);
-					}
-					// Filter out built-ins and constructor properties which come from dojo/_base/declare
-					else if (k !== 'constructor' && object.properties[k].file) {
-						propertyMetadata = object.properties[k].metadata;
-						additionalDescription += stringUtil.substitute(propertyTemplate, {
-							key: k,
-							type: propertyMetadata.type ? ' (' + propertyMetadata.type + (propertyMetadata.isOptional ? ', optional' : '') + ')' : '',
-							summary: propertyMetadata.summary ? ': ' + propertyMetadata.summary : ''
-						});
-					}
-				}
-			}
-		}(annotationObject));
-
-		metadata.description = (metadata.description || '') + parseMarkdown(additionalDescription);
+		// defer resolving this to do it in the exporter.  annotationObject might be the return
+		// value of the module currently being processed and in that case it won't have been tagged
+		// with a relatedModule yet.
+		metadata.type = annotationObject;
 	}
 
 	/**

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -370,8 +370,11 @@ define([
 				candidate = /^[^\n]*\/\/(.*?)\n/.exec(util.getSourceForRange(value.raw.range));
 
 				if (candidate) {
-					metadata = { type: trim(candidate[1]) };
+					value.evaluated.metadata.type = trim(candidate[1]);
+					processTypeAnnotation(value.evaluated.metadata);
 				}
+				// if we get here, we have no need to mixin any metadata
+				return;
 			}
 
 			// Function or object body

--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -7,37 +7,12 @@ define([
 	'dojo/node!../marked/lib/marked.js'
 ], function (lang, stringUtil, Value, env, util, marked) {
 	/**
-	 * Parses a markdown-enabled block of text into HTML, including the custom block extension for code samples.
+	 * Parses a markdown-enabled block of text into HTML.
 	 * @param text Markdown text.
 	 * @returns {string} HTML.
 	 */
 	function parseMarkdown(/**string*/ text) {
-		var tokens = marked.lexer(text);
-
-		for (var index = 0, token; (token = tokens[index]); ++index) {
-			if (token.type === 'paragraph' && /^\s*\|\s*/m.test(token.text)) {
-				var newTokens = [],
-					lastToken = {};
-
-				token.text.split('\n').forEach(function (line) {
-					var lineType = /^\s*\|/.test(line) ? 'code' : 'paragraph';
-
-					line = line.replace(/^\s*\|/, '');
-
-					if (lineType === lastToken.type) {
-						lastToken.text += (lastToken.text.length ? '\n' : '') + line;
-					}
-					else {
-						newTokens.push((lastToken = { type: lineType, text: line }));
-					}
-				});
-
-				tokens.splice.apply(tokens, [ index, 1 ].concat(newTokens));
-				index += newTokens.length - 1;
-			}
-		}
-
-		return marked.parser(tokens);
+		return marked(text);
 	}
 
 	/**
@@ -238,9 +213,11 @@ define([
 				properties: {}
 			},
 			keyIndent = indentRe.exec(comment[0])[0].length,
-			valueIndent,	// indent of the line after the current key
+			valueIndentRe, // regex to remove indent for the block of text under a key, but not indent within the block
+			codeBlockRe, // regex to remove indent unwanted characters from code block, but don't remove wanted indent
 			line,
-			key;
+			key,
+			prevLineType;
 
 		while ((line = comment.shift()) != null) {
 			// New metadata key
@@ -251,7 +228,9 @@ define([
 				key = standardKeys[keyLine[1]] || keyLine[1];
 
 				// Flag that when we read the next line, need to measure the indent
-				valueIndent = 0;
+				valueIndentRe = null;
+
+				prevLineType = "";	// because we haven't see any lines of the value yet
 
 				// TODO messages look exactly like a property or parameter definition, but they aren’t, so
 				// ignore them
@@ -309,25 +288,53 @@ define([
 			// Continuation of previous key
 			else if (key) {
 
-				if(!valueIndent /* && line */){
-					// First (non-blank) line after a key.  Use this line to measure the base indent of the value of this key.
-					try {
-						valueIndent = indentRe.exec(line)[0].length;
-					}catch(e){
-						console.error("Error measuring indent of line: " + line + " after key: " + key);
-						throw e;
-					}
-				}
-
 				// Trim the indentation that's part of dojodoc, but not the indentation that's part of markdown,
-				// representing nested lists or code blocks.
-				line = line.substr(valueIndent);
+				// representing nested lists or code blocks.   Also do conversion of text w/vertical bars representing
+				// code blocks to standard markdown, by indenting those lines four spaces, and adding newlines.
+
+				if(/^\s*\|/.test(line)){
+					// Code block in proprietary dojodoc format (with vertical bars)
+					if(prevLineType == "text" || !prevLineType){
+						// First line of the code block.  Setup regex to remove leading spaces and vertical bar,
+						// but not nested indent, ex:
+						//		|	this line shouldn't be indented
+						//		|		but this line should
+						var codeBlockIndent = indentRe.exec(line)[0].length;
+						codeBlockRe = new RegExp("^[\\s|]{0," + codeBlockIndent + "}");
+					}
+					if(prevLineType == "text"){
+						// blank line to separate this code block from preceding text, plus four spaces indent
+						line = line.replace(codeBlockRe, "\n    ");
+					}else{
+						// four spaces of indent to continue this code block
+						line = line.replace(codeBlockRe, "    ")
+					}
+					prevLineType = "code";
+				}else{
+					// Standard markdown, except for extra indentation of valueIndent characters
+
+					if(prevLineType == "code"){
+						// blank line to separate this text from previous code block
+						line += "\n";
+					}
+
+					if(!valueIndentRe && line){
+						// First non-blank non-code line after a key.  Use this line to measure the base indent.
+						var valueIndent = indentRe.exec(line)[0].length;
+						valueIndentRe = new RegExp("^\\s{0," + valueIndent + "}");	// remove up to valueIndent spaces
+					}
+
+					if(valueIndentRe){
+						line = line.replace(valueIndentRe, "");
+					}
+					prevLineType = "text";
+				}
 
 				if (!forKey && standardKeys.hasOwnProperty(key)) {
 					processStandardKey(metadata, key, line);
 				}
 				else {
-					metadata.properties[key].summary += (metadata.properties[key].summary.length ? '\n' : '') + line.replace(/^\s*/, '');
+					metadata.properties[key].summary += (metadata.properties[key].summary.length ? '\n' : '') + line;
 				}
 			}
 		}

--- a/tests/dojodoc.js
+++ b/tests/dojodoc.js
@@ -11,10 +11,6 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 		//			- nested list item two
 		//		- third list item
 		//
-		//		Code example:
-		// |	var foo = 3;
-		// |	var bar = 5;
-		//
 		//		And another paragraph.
 		//	foo: foo-type?
 		//		A property that only exists in your mind.
@@ -29,6 +25,12 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 		//			- world 1
 		//			- world 2
 		//		- goodbye
+		//
+		//		Code example:
+		// |	if(true){
+		// |		(only) this line should be indented
+		// |	}
+		//		And another paragraph.
 
 		//	obj: Object?
 		//		An optional object with an explicit type.
@@ -53,6 +55,21 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 
 			return a + // return-type
 				b;
+		},
+
+		addClassFx: function(cssClass, args){
+			// summary:
+			//		Animate the effects of adding a class to all nodes in this list.
+			//		see `dojox.fx.addClass`
+			// tags:
+			//		FX, NodeList
+			// example:
+			//	|	// fade all elements with class "bar" to to 50% opacity
+			//	|	dojo.query(".bar").addClassFx("bar").play();
+
+			return coreFx.combine(this.map(function(n){ // dojo.Animation
+				return styleX.addClass(n, cssClass, args);
+			}));
 		}
 	});
 

--- a/tests/dojodoc.js
+++ b/tests/dojodoc.js
@@ -4,6 +4,18 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 		//		A sample constructor that is not publicly exposed.
 		//	description:
 		//		This also features a _description_, which is made out of *Markdown*.
+		//
+		//		- first list item
+		//		- second list item
+		//			- nested list item one
+		//			- nested list item two
+		//		- third list item
+		//
+		//		Code example:
+		// |	var foo = 3;
+		// |	var bar = 5;
+		//
+		//		And another paragraph.
 		//	foo: foo-type?
 		//		A property that only exists in your mind.
 	});
@@ -11,6 +23,12 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 	var External = declare(Internal, {
 		//	summary:
 		//		A sample declare module.
+		//
+		//		- hello
+		//		- world
+		//			- world 1
+		//			- world 2
+		//		- goodbye
 
 		//	obj: Object?
 		//		An optional object with an explicit type.
@@ -41,6 +59,8 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 	External.fn2 = function () {
 		//	summary:
 		//		A static function.
+		//	returns: another-return-type
+		//		This one has the return type specified in the comment
 	};
 
 	return External;

--- a/tests/dojodoc.js
+++ b/tests/dojodoc.js
@@ -52,6 +52,14 @@ define([ 'dojo/_base/declare', 'dojo/Stateful' ], function (declare, Stateful) {
 			//		Optional string type in parameters.
 			//	c: c-type
 			//		Boolean type in comment.
+			//	returns: Boolean
+			//		Markdown return description
+			//
+			//		1. one
+			//		2. two
+			//		3. three
+			//
+			//		End of description
 
 			return a + // return-type
 				b;


### PR DESCRIPTION
Keeps track of which indentation is part of the markdown, and which isn't, so that nested lists and code blocks are parsed correctly.   Also fixes tab --> space conversion.

Fixes #56.
