### PR TITLE
skip dojox/app/build

### DIFF
--- a/config.js
+++ b/config.js
@@ -59,6 +59,9 @@ define({
 		// Non-API code
 		/\/(?:tests|nls|demos)\//,
 
+		// used for builds, not part of source
+		/dojox\/app\/build/,
+
 		// Overwrites dojo.declare
 		/dojox\/lang\/(?:docs|typed)/
 	]


### PR DESCRIPTION
That code is for the builder, not to be used as part of dojox/app, and the MIDs in define()
don't make sense.

See https://github.com/dmachi/dojox_application/commit/ac8e05a4a35f65f185a26f91addf2f738938aa02#commitcomment-2236734.
