### PR TITLE
prevent property metadata overriding value metadata

### DIFF
--- a/lib/processor/dojodoc.js
+++ b/lib/processor/dojodoc.js
@@ -438,6 +438,9 @@ define([
 
 					metadata = (processComment(candidate.value, value.raw.key.name).properties || {})[value.raw.key.name];
 					processTypeAnnotation(metadata);
+					// the localised property metadata will override the metadata inherited from the value
+					context.evaluated.properties[value.raw.key.name].metadata = metadata;
+					return;
 				}
 			}
 


### PR DESCRIPTION
this makes a property's metadata independent of the value's metadata.

fixes #61
